### PR TITLE
Cleanup the `parser` before debugging

### DIFF
--- a/bitwig/preset_parser/presetparser.mojo
+++ b/bitwig/preset_parser/presetparser.mojo
@@ -1,10 +1,12 @@
 from builtin.io import _printf as printf
 
+alias Bytes = List[Byte]
+
 @value
 struct ReadResult(Boolable, Stringable):
   var pos: Int
   var size: Int
-  var data: List[Byte]
+  var data: Bytes
 
   fn __bool__(self) -> Bool:
     return self.size > 0
@@ -22,10 +24,10 @@ struct ReadResult(Boolable, Stringable):
 struct PresetParser:
   var debug: Bool
 
-  fn __init__(mut self) raises:
+  fn __init__(out self):
     self.debug = False
 
-  fn process_preset(read self, file_name: String) raises:
+  fn process_preset(self, file_name: String) raises:
     var pos: Int = 0x36
 
     var f = open(file_name, "r")
@@ -35,44 +37,44 @@ struct PresetParser:
       if result.size == 0: break
     f.close()
 
-  fn read_key_and_value(read self, f: FileHandle, mut pos: Int) raises -> ReadResult:
+  fn read_key_and_value(self, f: FileHandle, mut pos: Int) raises -> ReadResult:
     var skips = self.get_skip_size(f, pos)
     if self.debug:
       self.get_skip_size_debug(f, pos)
-      print(String(skips) + " skips")
+      print(skips, "skips")
     pos += skips
 
     var result = self.read_next_size_and_chunk(f, pos)
     pos = result.pos
     var size = result.size
     var data = result.data
-    if size == 0: return ReadResult(0, 0, List[UInt8]())
+    if size == 0: return ReadResult(0, 0, Bytes())
     printf["[%s] "](self.vec_to_string(data))
 
     skips = self.get_skip_size(f, pos)
     if self.debug:
       self.get_skip_size_debug(f, pos)
-      print(String(skips) + " skips")
+      print(skips, "skips")
     pos += skips
 
     result = self.read_next_size_and_chunk(f, pos)
     printf["%s\n"](self.vec_to_string(result.data))
-    return ReadResult(result.pos, result.size, List[UInt8]())
+    return ReadResult(result.pos, result.size, Bytes())
 
-  fn get_skip_size(read self, f: FileHandle, mut pos: Int) raises -> Int:
+  fn get_skip_size(self, f: FileHandle, mut pos: Int) raises -> Int:
     var bytes = self.read_from_file(f, pos, 32, True).data
-    for i in range(0, bytes.__len__()):
+    for i in range(len(bytes)):
       if bytes[i] >= 0x20 and (i == 5 or i == 8 or i == 13):
         return i - 4
     return 1
 
-  fn get_skip_size_debug(read self, f: FileHandle, mut pos: Int) raises:
+  fn get_skip_size_debug(self, f: FileHandle, mut pos: Int) raises:
     var bytes = self.read_from_file(f, pos, 32, True).data
     printf["\n"]()
-    for b in range(0, bytes.__len__()):
+    for b in range(len(bytes)):
       printf["%02x "](bytes[b])
     print()
-    for b in range(0, bytes.__len__()):
+    for b in range(len(bytes)):
       if bytes[b] >= 0x31:
         printf[".%c."](bytes[b])
       else:
@@ -80,24 +82,24 @@ struct PresetParser:
     print()
 
   fn read_next_size_and_chunk(self, f: FileHandle, mut pos: Int) raises -> ReadResult:
-    var int_chunk = self.read_int_chunk(f, pos);
-    if (int_chunk.size == 0):
-      return ReadResult(pos, 0, List[UInt8]())
+    var int_chunk = self.read_int_chunk(f, pos)
+    if not int_chunk:
+      return ReadResult(pos, 0, Bytes())
     return self.read_from_file(f, int_chunk.pos, int_chunk.size, True)
 
   fn read_int_chunk(self, f: FileHandle, mut pos: Int) raises -> ReadResult:
     var new_read = self.read_from_file(f, pos, 4, True)
-    if len(new_read.data) == 0:
-      return ReadResult(0, 0, List[UInt8]())
+    if not new_read.data:
+      return ReadResult(0, 0, Bytes())
     pos = new_read.pos
     var size: UInt32 = 0
-    for i in range(0, 4):
+    for i in range(4):
       size |= new_read.data[i].cast[DType.uint32]() << ((3 - i) * 8)
-    return ReadResult(pos, size.__int__(), List[UInt8]())
+    return ReadResult(pos, Int(size), Bytes())
 
   @staticmethod
-  fn print_byte_vector(data: List[UInt8]) raises:
-    for i in range(0, data.__len__()):
+  fn print_byte_vector(data: Bytes):
+    for i in range(len(data)):
       printf["%02x "](data[i])
     print()
 
@@ -106,14 +108,14 @@ struct PresetParser:
     try:
       _ = f.seek(pos)
     except:
-      return ReadResult(0, 0, List[UInt8]())
-    var data: List[UInt8] = f.read_bytes(size)
+      return ReadResult(0, 0, Bytes())
+    var data: Bytes = f.read_bytes(size)
     return ReadResult(pos + size if advance else 0, size, data)
 
   @staticmethod
-  fn vec_to_string(data: List[UInt8]) raises -> String:
+  fn vec_to_string(data: Bytes) -> String:
     var result = String()
-    for i in range(0, len(data)):
+    for i in range(len(data)):
       if data[i] == 0x00:
         break
       result += chr(data[i].__int__())

--- a/bitwig/preset_parser/presetparser.mojo
+++ b/bitwig/preset_parser/presetparser.mojo
@@ -1,17 +1,20 @@
 from builtin.io import _printf as printf
 
 @value
-struct ReadResult(StringableRaising):
+struct ReadResult(Stringable):
   var pos: Int
   var size: Int
-  var data: List[UInt8]
+  var data: List[Byte]
 
-  fn __str__(self) raises -> String:
-    var result = "pos: " + String(self.pos) + " size: " + String(self.size) + " data: ["
-    for i in range(0, self.data.__len__()):
-      result += String(self.data[i]) + " "
-    result += "]"
-    return result
+  fn __str__(self) -> String:
+    var data = String()
+    for b in self.data:
+      data.write(b[], " ")
+    return String(
+      "pos: ", self.pos, ", ",
+      "size: ", self.size, ", ",
+      "data: [", data[:-1] if data else "", "]"
+    )
 
 struct PresetParser:
   var debug: Bool

--- a/bitwig/preset_parser/presetparser.mojo
+++ b/bitwig/preset_parser/presetparser.mojo
@@ -1,10 +1,13 @@
 from builtin.io import _printf as printf
 
 @value
-struct ReadResult(Stringable):
+struct ReadResult(Boolable, Stringable):
   var pos: Int
   var size: Int
   var data: List[Byte]
+
+  fn __bool__(self) -> Bool:
+    return self.size > 0
 
   fn __str__(self) -> String:
     var data = String()


### PR DESCRIPTION
@carlca I suggest we gradually pin down the semantics of this module by cleaning up the code and adding small unit tests before tackling the bug itself. WDYT?